### PR TITLE
Slim Recent: fix topmost app when using lastapp action

### DIFF
--- a/src/com/android/internal/utils/du/ActionHandler.java
+++ b/src/com/android/internal/utils/du/ActionHandler.java
@@ -669,6 +669,7 @@ public class ActionHandler {
         if (lastTask != null) {
             am.moveTaskToFront(lastTask.id, ActivityManager.MOVE_TASK_NO_USER_ACTION);
         }
+        cancelPreloadRecentApps();
     }
 
     private static ActivityManager.RunningTaskInfo getLastTask(Context context,


### PR DESCRIPTION
we need to cancel preloading so at next Recents call tasks
are loaded again